### PR TITLE
Redesign text layout shaping.

### DIFF
--- a/src/import/eval.rs
+++ b/src/import/eval.rs
@@ -1457,6 +1457,16 @@ impl<'a, B: Builtin> ArgumentList<'a, B> {
         self.arguments.is_empty()
     }
 
+    pub fn into_empty(self, err: &mut EvalErrors) -> Result<(), Failed> {
+        if !self.is_empty() {
+            err.add(self.pos, format!("expected zero arguments"));
+            Err(Failed)
+        }
+        else {
+            Ok(())
+        }
+    }
+
     pub fn into_array<const N: usize>(
         self, err: &mut EvalErrors,
     ) -> Result<[Expression<'a, B>; N], Failed> {

--- a/src/render/text.rs
+++ b/src/render/text.rs
@@ -76,23 +76,9 @@ impl TextMetrics {
         self.logical
     }
 
-    /*
-    pub fn advance(&self) -> Point {
-        Point::new(self.text.x_advance(), self.text.y_advance())
+    pub fn center(&self) -> Point {
+        self.ink.center()
     }
-
-    pub fn ascent(&self) -> f64 {
-        self.font.ascent()
-    }
-
-    pub fn descent(&self) -> f64 {
-        self.font.descent()
-    }
-
-    pub fn line_height(&self) -> f64 {
-        self.font.height()
-    }
-    */
 }
 
 fn rect_from_pango(rect: pango::Rectangle) -> Rect {


### PR DESCRIPTION
This PR redesigns how text layouts are shaped. It primarily changes how the vertical and horizontal bases of boxes are calculated. This allows for more options to choose from where defining where the base should be and adds explicit anchor items that can be referred to when defining the base.